### PR TITLE
Make unpack_nested_data a lot more flexible with supported column types

### DIFF
--- a/r-pkg/uptasticsearch/man/unpack_nested_data.Rd
+++ b/r-pkg/uptasticsearch/man/unpack_nested_data.Rd
@@ -9,13 +9,15 @@ unpack_nested_data(chomped_df, col_to_unpack)
 \arguments{
 \item{chomped_df}{a data.table}
 
-\item{col_to_unpack}{a character vector of length one: the column name to unpack}
+\item{col_to_unpack}{a character vector of length one: the column name to 
+unpack}
 }
 \description{
-After calling an \code{Chomp*} function, if you had a nested array in the JSON, 
-             its corresponding column in the resulting data.table is a data.frame itself. This 
-             function expands that data.frame out, adding its columns to the original data.table, 
-             and duplicating metadata down the rows as necessary.
+After calling a \code{chomp_*} function or \code{es_search}, if 
+  you had a nested array in the JSON, its corresponding column in the 
+  resulting data.table is a data.frame itself (or a list of vectors). This 
+  function expands that nested column out, adding its data to the original 
+  data.table, and duplicating metadata down the rows as necessary.
 }
 \examples{
 # Chomp a dummy sample JSON of hits

--- a/r-pkg/uptasticsearch/tests/testthat/test-elasticsearch_parsers.R
+++ b/r-pkg/uptasticsearch/tests/testthat/test-elasticsearch_parsers.R
@@ -853,6 +853,26 @@ futile.logger::flog.threshold(0)
               expect_true(sum(is.na(unpackedDT$minutes)) == 6)
              })
     
+    # Should work if the array is a simple array rather than an array of maps
+    test_that("unpack_nested_data should work if the array is a simple array",
+              {test_json <- '[{"_source":{"dateTime":"2017-01-01","username":"Austin1","details":{
+              "interactions":400,"userType":"active","minutes":[500,350,422]}}},
+              {"_source":{"dateTime":"2017-02-02","username":"Austin2","details":{"interactions":0,
+              "userType":"never","minutes":[]}}},
+              {"_source":{"dateTime":"2017-03-03","username":"Austin3","details":{"interactions":5,
+              "userType":"very_active","minutes":[28,190,1,796]}}}]'
+              sampleChompedDT <- chomp_hits(test_json
+                                            , keep_nested_data_cols = TRUE)
+              unpackedDT <- unpack_nested_data(chomped_df = sampleChompedDT
+                                               , col_to_unpack = "details.minutes")
+              expect_true("data.table" %in% class(unpackedDT))
+              expect_equivalent(dim(unpackedDT), c(8, 5))
+              expect_named(unpackedDT, c('details.minutes', 'dateTime', 'username',
+                                         'details.interactions', 'details.userType'))
+              expect_equivalent(unpackedDT$details.minutes, c(500, 350, 422, NA, 28, 190, 1, 796))
+              expect_identical(unpackedDT$username, c(rep("Austin1", 3), "Austin2", rep("Austin3", 4)))
+              })
+    
     # Should break if chomped_df is not a data.table
     test_that("unpack_nested_data should break if you don't pass a data.table",
               {expect_error(unpack_nested_data(chomped_df = 42
@@ -887,6 +907,13 @@ futile.logger::flog.threshold(0)
                                                , col_to_unpack = "a"),
                             regexp = "col_to_unpack must be one of the column names")}
              )
+    
+    # Should break if the column doesn't include any data
+    test_that("unpack_nested_data should break if the column doesn't include any data",
+              {expect_error(unpack_nested_data(chomped_df = data.table::data.table(wow = 7, dang = list())
+                                               , col_to_unpack = "dang"),
+                            regexp = "The column given to unpack_nested_data had no data in it")}
+    )
     
 #---- 5. .ConvertToSec
     

--- a/r-pkg/uptasticsearch/tests/testthat/test-elasticsearch_parsers.R
+++ b/r-pkg/uptasticsearch/tests/testthat/test-elasticsearch_parsers.R
@@ -888,13 +888,6 @@ futile.logger::flog.threshold(0)
                             regexp = "col_to_unpack must be one of the column names")}
              )
     
-    # Should break if the specified column is not a list of data.frames
-    test_that("unpack_nested_data should break if the specified column is not a list of data.frames",
-              {expect_error(unpack_nested_data(chomped_df = data.table::data.table(wow = 7)
-                                               , col_to_unpack = "wow"),
-                            regexp = "the column specified is not a list of data.frames")}
-             )
-    
 #---- 5. .ConvertToSec
     
     # .ConvertToSec should work for seconds


### PR DESCRIPTION
Now this can handle columns that are arrays of simple objects like strings, rather than just arrays of maps.