### PR TITLE
Fix bug when query return 0 hit

### DIFF
--- a/r-pkg/DESCRIPTION
+++ b/r-pkg/DESCRIPTION
@@ -6,6 +6,7 @@ Authors@R: c(
     person("James", "Lamb", email = "james.lamb@uptake.com", role = c("aut", "cre")),
     person("Nick", "Paras", email = "nick.paras@uptake.com", role = c("aut")),
     person("Austin", "Dickey", email = "austin.dickey@uptake.com", role = c("aut")),
+    person("Weiwen", "Gu", email = "weiwen.gu@uptake.com", role = c("ctb")),
     person("Uptake Technologies Inc.", role = c("cph")))
 Maintainer: James Lamb <james.lamb@uptake.com>
 Description:

--- a/r-pkg/R/elasticsearch_parsers.R
+++ b/r-pkg/R/elasticsearch_parsers.R
@@ -806,6 +806,9 @@ es_search <- function(es_host
     hits_pulled <- length(firstResult[["hits"]][["hits"]])
     
     if (hits_pulled == 0) {
+      msg <- paste0('Query is syntactically valid but 0 documents was matched.'
+                    , 'Returning NULL')
+      warning(msg)
       return(NULL)
     }
     

--- a/r-pkg/R/elasticsearch_parsers.R
+++ b/r-pkg/R/elasticsearch_parsers.R
@@ -804,6 +804,11 @@ es_search <- function(es_host
     
     # If we got everything possible, just return here
     hits_pulled <- length(firstResult[["hits"]][["hits"]])
+    
+    if (hits_pulled == 0) {
+      return(NULL)
+    }
+    
     if (hits_pulled == hits_to_pull) {
         # Parse to data.table
         esDT <- chomp_hits(hits_json = firstResultJSON

--- a/r-pkg/R/elasticsearch_parsers.R
+++ b/r-pkg/R/elasticsearch_parsers.R
@@ -808,6 +808,7 @@ es_search <- function(es_host
     if (hits_pulled == 0) {
       msg <- paste0('Query is syntactically valid but 0 documents was matched. '
                     , 'Returning NULL')
+      futile.logger::flog.warn(msg)
       warning(msg)
       return(NULL)
     }
@@ -1033,6 +1034,7 @@ es_search <- function(es_host
     if (! grepl(protocolPattern, es_host) == 1){
         msg <- paste0('You did not provide a transfer protocol (e.g. http://) with es_host.'
                       , 'Assuming http://...')
+        futile.logger::flog.warn(msg)
         warning(msg)
         
         # Doing this to avoid cases where you just missed a slash or something,

--- a/r-pkg/R/elasticsearch_parsers.R
+++ b/r-pkg/R/elasticsearch_parsers.R
@@ -806,7 +806,7 @@ es_search <- function(es_host
     hits_pulled <- length(firstResult[["hits"]][["hits"]])
     
     if (hits_pulled == 0) {
-      msg <- paste0('Query is syntactically valid but 0 documents was matched.'
+      msg <- paste0('Query is syntactically valid but 0 documents was matched. '
                     , 'Returning NULL')
       warning(msg)
       return(NULL)

--- a/r-pkg/R/elasticsearch_parsers.R
+++ b/r-pkg/R/elasticsearch_parsers.R
@@ -806,7 +806,7 @@ es_search <- function(es_host
     hits_pulled <- length(firstResult[["hits"]][["hits"]])
     
     if (hits_pulled == 0) {
-      msg <- paste0('Query is syntactically valid but 0 documents was matched. '
+      msg <- paste0('Query is syntactically valid but 0 documents were matched. '
                     , 'Returning NULL')
       futile.logger::flog.warn(msg)
       warning(msg)

--- a/r-pkg/docs/authors.html
+++ b/r-pkg/docs/authors.html
@@ -100,7 +100,11 @@
         </p>
       </li>
       <li>
-        <p><strong>Uptake Technologies Inc.</strong>. Copyright&nbsp;holder.
+        <p><strong>Weiwen Gu</strong>. Contributor.
+        </p>
+      </li>
+      <li>
+        <p><strong>Uptake Technologies Inc.</strong>. Copyright holder.
         </p>
       </li>
     </ul>

--- a/r-pkg/docs/reference/chomp_hits.html
+++ b/r-pkg/docs/reference/chomp_hits.html
@@ -126,8 +126,8 @@ arrays in the original JSON. A warning will be given if these columns are delete
 "film":"Avengers: Infinity War","pmt_amount":12.75}]}}}]'</span>
 
 <span class='co'># Chomp into a data.table</span>
-<span class='no'>sampleChompedDT</span> <span class='kw'>&lt;-</span> <span class='fu'>chomp_hits</span>(<span class='kw'>hits_json</span> <span class='kw'>=</span> <span class='no'>result</span>, <span class='kw'>keep_nested_data_cols</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>)</div><div class='output co'>#&gt; INFO [2017-07-18 10:45:42] Keeping the following nested data columns. Consider using unpack_nested_data for one:
-#&gt;  details.pastPurchases</div><div class='input'><span class='fu'>print</span>(<span class='no'>sampleChompedDT</span>)</div><div class='output co'>#&gt;     timestamp cust_name details.cust_class details.location
+<span class='no'>sampleChompedDT</span> <span class='kw'>&lt;-</span> <span class='fu'>chomp_hits</span>(<span class='kw'>hits_json</span> <span class='kw'>=</span> <span class='no'>result</span>, <span class='kw'>keep_nested_data_cols</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>)
+<span class='fu'>print</span>(<span class='no'>sampleChompedDT</span>)</div><div class='output co'>#&gt;     timestamp cust_name details.cust_class details.location
 #&gt; 1: 2017-01-01    Austin        big_spender          chicago
 #&gt; 2: 2017-02-02     James            peasant          chicago
 #&gt; 3: 2017-03-03      Nick             critic           cannes

--- a/r-pkg/docs/reference/es_search.html
+++ b/r-pkg/docs/reference/es_search.html
@@ -93,7 +93,7 @@
     
 
     <pre class="usage"><span class='fu'>es_search</span>(<span class='no'>es_host</span>, <span class='no'>es_index</span>, <span class='kw'>size</span> <span class='kw'>=</span> <span class='fl'>10000</span>, <span class='kw'>query_body</span> <span class='kw'>=</span> <span class='st'>"{}"</span>,
-  <span class='kw'>scroll</span> <span class='kw'>=</span> <span class='st'>"5m"</span>, <span class='kw'>max_hits</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
+  <span class='kw'>scroll</span> <span class='kw'>=</span> <span class='st'>"5m"</span>, <span class='kw'>max_hits</span> <span class='kw'>=</span> <span class='fl'>Inf</span>,
   <span class='kw'>n_cores</span> <span class='kw'>=</span> <span class='fu'>ceiling</span>(<span class='kw pkg'>parallel</span><span class='kw ns'>::</span><span class='fu'><a href='http://www.rdocumentation.org/packages/parallel/topics/detectCores'>detectCores</a></span>()/<span class='fl'>2</span>), <span class='kw'>break_on_duplicates</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>,
   <span class='kw'>ignore_scroll_restriction</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>, <span class='kw'>intermediates_dir</span> <span class='kw'>=</span> <span class='fu'>getwd</span>())</pre>
     
@@ -131,7 +131,9 @@ for more information.</p></td>
     </tr>
     <tr>
       <th>max_hits</th>
-      <td><p>Integer. If specified, <code>es_search</code> will stop pulling data as soon as it has pulled this many hits.</p></td>
+      <td><p>Integer. If specified, <code>es_search</code> will stop pulling data as soon
+as it has pulled this many hits. Default is <code>Inf</code>, meaning that
+all possible hits will be pulled.</p></td>
     </tr>
     <tr>
       <th>n_cores</th>

--- a/r-pkg/docs/reference/unpack_nested_data.html
+++ b/r-pkg/docs/reference/unpack_nested_data.html
@@ -128,8 +128,8 @@ unpack</p></td>
 "film":"Avengers: Infinity War","pmt_amount":12.75}]}}}]'</span>
 
 <span class='co'># Chomp into a data.table</span>
-<span class='no'>sampleChompedDT</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='chomp_hits.html'>chomp_hits</a></span>(<span class='kw'>hits_json</span> <span class='kw'>=</span> <span class='no'>result</span>, <span class='kw'>keep_nested_data_cols</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>)</div><div class='output co'>#&gt; INFO [2017-07-18 10:45:43] Keeping the following nested data columns. Consider using unpack_nested_data for one:
-#&gt;  details.pastPurchases</div><div class='input'><span class='fu'>print</span>(<span class='no'>sampleChompedDT</span>)</div><div class='output co'>#&gt;     timestamp cust_name details.cust_class details.location
+<span class='no'>sampleChompedDT</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='chomp_hits.html'>chomp_hits</a></span>(<span class='kw'>hits_json</span> <span class='kw'>=</span> <span class='no'>result</span>, <span class='kw'>keep_nested_data_cols</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>)
+<span class='fu'>print</span>(<span class='no'>sampleChompedDT</span>)</div><div class='output co'>#&gt;     timestamp cust_name details.cust_class details.location
 #&gt; 1: 2017-01-01    Austin        big_spender          chicago
 #&gt; 2: 2017-02-02     James            peasant          chicago
 #&gt; 3: 2017-03-03      Nick             critic           cannes


### PR DESCRIPTION
Fixed a bug in which `es_search` error out when query return 0 hit.
It now return `NULL`. A warning will be throw before returning `NULL`
Remade docs