### PR TITLE
Add Elasticsearch integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,96 @@ language: R
 cache: packages
 warnings_are_errors: true
 
+addons:
+  apt:
+    packages:
+      - oracle-java8-set-default
+
+env:
+  matrix:
+  - ES_VERSION=1.0.0
+  - ES_VERSION=1.4.0
+  - ES_VERSION=1.7.2
+  - ES_VERSION=2.0.0
+  - ES_VERSION=2.1.0
+  - ES_VERSION=2.2.0
+  - ES_VERSION=2.3.0
+  - ES_VERSION=5.0.0
+  - ES_VERSION=5.3.0
+  - ES_VERSION=5.4.0
+  - ES_VERSION=5.5.0
+
 before_install:
-- cd r-pkg
+  - case "$ES_VERSION" in
+    "") ;;
+
+    "1.0.0")
+      export ES_VERSION=1.0.0 ;
+      curl -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-$ES_VERSION.deb && sudo dpkg -i --force-confnew elasticsearch-$ES_VERSION.deb && sudo service elasticsearch start
+      ;;
+
+    "1.4.0")
+      export ES_VERSION=1.4.0 ;
+      curl -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-$ES_VERSION.deb && sudo dpkg -i --force-confnew elasticsearch-$ES_VERSION.deb && sudo service elasticsearch start
+      ;;
+
+    "1.7.2")
+      export ES_VERSION=1.7.2 ;
+      curl -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-$ES_VERSION.deb && sudo dpkg -i --force-confnew elasticsearch-$ES_VERSION.deb && sudo service elasticsearch start
+      ;;
+
+    "2.0.0")
+      export ES_VERSION=2.0.0 ;
+      curl -O https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/$ES_VERSION/elasticsearch-$ES_VERSION.deb && sudo dpkg -i --force-confnew elasticsearch-$ES_VERSION.deb && sudo service elasticsearch start
+      ;;
+
+    "2.1.0")
+      export ES_VERSION=2.1.0 ;
+      curl -O https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/$ES_VERSION/elasticsearch-$ES_VERSION.deb && sudo dpkg -i --force-confnew elasticsearch-$ES_VERSION.deb && sudo service elasticsearch start
+      ;;
+
+    "2.2.0")
+      export ES_VERSION=2.2.0 ;
+      curl -O https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/$ES_VERSION/elasticsearch-$ES_VERSION.deb && sudo dpkg -i --force-confnew elasticsearch-$ES_VERSION.deb && sudo service elasticsearch start
+      ;;
+
+    "2.3.0")
+      export ES_VERSION=2.3.0 ;
+      curl -O https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/$ES_VERSION/elasticsearch-$ES_VERSION.deb && sudo dpkg -i --force-confnew elasticsearch-$ES_VERSION.deb && sudo service elasticsearch start
+      ;;
+
+    "5.0.0")
+      export ES_VERSION=5.0.0 ;
+      curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$ES_VERSION.deb && sudo dpkg -i --force-confnew elasticsearch-$ES_VERSION.deb && sudo service elasticsearch start
+      ;;
+
+    "5.3.0")
+      export ES_VERSION=5.3.0 ;
+      curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$ES_VERSION.deb && sudo dpkg -i --force-confnew elasticsearch-$ES_VERSION.deb && sudo service elasticsearch start
+      ;;
+    
+    "5.4.0")
+      export ES_VERSION=5.4.0 ;
+      curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$ES_VERSION.deb && sudo dpkg -i --force-confnew elasticsearch-$ES_VERSION.deb && sudo service elasticsearch start
+      ;;
+
+    "5.5.0")
+      export ES_VERSION=5.5.0 ;
+      curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$ES_VERSION.deb && sudo dpkg -i --force-confnew elasticsearch-$ES_VERSION.deb && sudo service elasticsearch start
+      ;;
+   esac
+
+  - sleep 20
+  - sudo service elasticsearch status
+  - wget https://download.elastic.co/demos/kibana/gettingstarted/shakespeare.json -O shakespeare.json
+  - mv r-pkg/inst/testdata/shakespeare_mapping.json shakespeare_mapping.json
+  - echo $(ls)
+  - curl --silent -X PUT "http://127.0.0.1:9200/shakespeare" -d @shakespeare_mapping.json
+  - head -10000 shakespeare.json > sample_data.json
+  - split -l 1000 sample_data.json data_
+  - for filename in $(ls | grep data_); do curl --silent -X POST "http://127.0.0.1:9200/shakespeare/_bulk" --data-binary "@$filename"; done
+  - curl -X GET "http://127.0.0.1:9200/shakespeare/_search?size=1"
+  - cd r-pkg
 
 after_success:
 - Rscript -e 'install.packages("covr"); covr::codecov()'

--- a/r-pkg/.Rbuildignore
+++ b/r-pkg/.Rbuildignore
@@ -3,3 +3,5 @@
 ^docs$
 ^_pkgdown\.yml$
 cran-comments.md
+tests/testthat/test-integration_tests.R
+inst/testdata/shakespeare_mapping.json

--- a/r-pkg/inst/testdata/shakespeare_mapping.json
+++ b/r-pkg/inst/testdata/shakespeare_mapping.json
@@ -1,0 +1,26 @@
+{
+  "mappings": {
+    "_default_": {
+      "properties": {
+        "speaker": {
+          "type": "keyword"
+        },
+        "play_name": {
+          "type": "keyword"
+        },
+        "line_id": {
+          "type": "integer"
+        },
+        "line_number": {
+          "type": "keyword"
+        },
+        "speech_number": {
+          "type": "integer"
+        },
+        "text_entry": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/r-pkg/tests/testthat/test-integration.R
+++ b/r-pkg/tests/testthat/test-integration.R
@@ -1,0 +1,37 @@
+context("Elasticsearch integration tests")
+
+# tests in this file are run automatically on Travis and require
+# an actual Elasticsearch cluster to be up and running. For details,
+# see: https://github.com/UptakeOpenSource/uptasticsearch/blob/master/.travis.yml
+
+# Sample data from:
+# - https://www.elastic.co/guide/en/kibana/current/tutorial-load-dataset.html
+
+# Configure logger (suppress all logs in testing)
+loggerOptions <- futile.logger::logger.options()
+if (!identical(loggerOptions, list())){
+    origLogThreshold <- loggerOptions[[1]][['threshold']]    
+} else {
+    origLogThreshold <- futile.logger::INFO
+}
+futile.logger::flog.threshold(0)
+
+#--- 1. es_search
+
+    # Works as expected
+    test_that("es_search works as expected for a simple request",
+              {testthat::skip_on_cran()
+                
+               outDT <- es_search(es_host = "http://127.0.0.1:9200"
+                                  , es_index = "shakespeare"
+                                  , max_hits = 100)
+
+               expect_true("data.table" %in% class(outDT))
+               expect_true(nrow(outDT) == 100)
+              }
+             )
+
+##### TEST TEAR DOWN #####
+futile.logger::flog.threshold(origLogThreshold)
+rm(list = ls())
+closeAllConnections()


### PR DESCRIPTION
In this PR, I added instructions for Travis to pull different versions of ES, spin up a 1-node cluster, and seed it with some test data. I also added a basic integration test just to be sure this is working.