### PR TITLE
Remove "old = names(DT)" from calls to data.table::setnames

### DIFF
--- a/R/elasticsearch_eda_funs.R
+++ b/R/elasticsearch_eda_funs.R
@@ -201,7 +201,7 @@ get_fields <- function(es_host
     # convert to data table and add the data type column
     mappingDT <- data.table::data.table(meta = mappingCols, data_type = as.character(flattened))
     newColNames <- c('index', 'type', 'field', 'data_type')
-    data.table::setnames(mappingDT, old = names(mappingDT), new = newColNames)
+    data.table::setnames(mappingDT, newColNames)
     
     # remove any rows, where the field does not end in ".type" to remove meta info
     mappingDT <- mappingDT[stringr::str_detect(field, '\\.type$')]

--- a/R/elasticsearch_parsers.R
+++ b/R/elasticsearch_parsers.R
@@ -225,7 +225,7 @@ chomp_aggs <- function(aggs_json = NULL) {
                 # If we get down here, we know it's not a bucketed aggregation
                 # So we want to take like "count", "min", "max" and change them to 
                 # e.g. "some_field.count", "some_field.min", "some_field.max"
-                data.table::setnames(outDT, names(outDT), paste0(aggNames, ".", names(outDT)))
+                data.table::setnames(outDT, paste0(aggNames, ".", names(outDT)))
             }
         }
         
@@ -514,7 +514,7 @@ chomp_hits <- function(hits_json = NULL, keep_nested_data_cols = TRUE) {
     }
     
     # Strip "_source" from all the column names because blegh
-    data.table::setnames(batchDT, old = names(batchDT), new = gsub("_source\\.", "", names(batchDT)))
+    data.table::setnames(batchDT, gsub("_source\\.", "", names(batchDT)))
     
     # Warn the user if there's nested data
     colTypes <- sapply(batchDT, mode)


### PR DESCRIPTION
Found instances where data.table set names was called all of the names of the passed in DT.  Changed these instances to use the format of data.table::setnames(DT, newNames)