### PR TITLE
Fix for data.table::setnames() potential bug

### DIFF
--- a/R/elasticsearch_eda_funs.R
+++ b/R/elasticsearch_eda_funs.R
@@ -201,7 +201,7 @@ get_fields <- function(es_host
     # convert to data table and add the data type column
     mappingDT <- data.table::data.table(meta = mappingCols, data_type = as.character(flattened))
     newColNames <- c('index', 'type', 'field', 'data_type')
-    data.table::setnames(mappingDT, old = names(mappingDT), new = newColNames)
+    data.table::setnames(mappingDT, newColNames)
     
     # remove any rows, where the field does not end in ".type" to remove meta info
     mappingDT <- mappingDT[stringr::str_detect(field, '\\.type$')]


### PR DESCRIPTION
Did not replace the ones in the shape of:

_data.table::setnames(outDT, names(outDT), paste0(aggNames, ".", names(outDT)))_

Because those would actually not break in the case of duplicated column names (old and new would have same length)