### PR TITLE
Fixed documentation for get_fields function

### DIFF
--- a/R/elasticsearch_eda_funs.R
+++ b/R/elasticsearch_eda_funs.R
@@ -137,7 +137,7 @@ get_counts <- function(field
 #' @return A data.table containing four columns: index, type, field, and data_type
 #' @examples \dontrun{
 #' # get the mapping for all indexed fields in the ticket_sales and customers indices
-#' mappingDT <- retrieve_mapping(es_host = "http://es.custdb.mycompany.com:9200"
+#' mappingDT <- get_fields(es_host = "http://es.custdb.mycompany.com:9200"
 #'                               , es_indices = c("ticket_sales", "customers"))
 #' }
 get_fields <- function(es_host

--- a/man/get_fields.Rd
+++ b/man/get_fields.Rd
@@ -25,7 +25,7 @@ For a given Elasticsearch index, return the mapping from field name
 \examples{
 \dontrun{
 # get the mapping for all indexed fields in the ticket_sales and customers indices
-mappingDT <- retrieve_mapping(es_host = "http://es.custdb.mycompany.com:9200"
+mappingDT <- get_fields(es_host = "http://es.custdb.mycompany.com:9200"
                               , es_indices = c("ticket_sales", "customers"))
 }
 }


### PR DESCRIPTION
Fixed the function name in documentation for get_fields() function. Changed it from retrieve_mapping to get_fields.