### PR TITLE
Add deprecation warning on get_counts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# uptasticsearch 0.3.0
+
+## Deprecations and Removals
+- [#69](https://github.com/UptakeOpenSource/uptasticsearch/pull/69) added a deprecation warning on `get_counts`. This function was outside the core mission of the package and exposed us unnecessarily to changes in the Elasticsearch DSL
+
 # uptasticsearch 0.2.0
 
 ## Features

--- a/R/elasticsearch_eda_funs.R
+++ b/R/elasticsearch_eda_funs.R
@@ -32,6 +32,7 @@
 #'                      , end_date = "now"
 #'                      , time_field = "dateTime")
 #' }
+#' @note \href{https://github.com/UptakeOpenSource/uptasticsearch/pull/69}{get_counts will be deprecated soon}
 get_counts <- function(field
                       , es_host
                       , es_index
@@ -42,6 +43,13 @@ get_counts <- function(field
                       , max_terms = 1000
 ){
     
+    msg <- paste0(
+      "get_counts is deprecated as of https://github.com/UptakeOpenSource/uptasticsearch/pull/69. It will be ",
+      "dropped in the next release of uptasticsearch. If you use this function, please open an issue at ",
+      "https://github.com/UptakeOpenSource/uptasticsearch/issues and let the maintainers know."
+    )
+    log_warn(msg)
+  
     # Input checking
     es_host <- .ValidateAndFormatHost(es_host)
     

--- a/man/get_counts.Rd
+++ b/man/get_counts.Rd
@@ -52,3 +52,6 @@ recoDT <- get_counts(field = "pmt_method"
                      , time_field = "dateTime")
 }
 }
+\references{
+\href{https://github.com/UptakeOpenSource/uptasticsearch/pull/69}{get_counts will be deprecated soon}
+}


### PR DESCRIPTION
**Overview**

In this PR, I'd like to propose deprecating `get_counts`. This function is not really central to what `uptasticsearch` does and will require extra administrative burden to test. As a reminder, `get_counts` basically generates queries to check the counts of different values on a field within a period of time.

This is outside of our mission for a couple of reasons:

* assumes that you have time-series data
* writes query DSL inside the package
* only useful for a very specific type of EDA

IMHO we should remove this function from the package.

**Deprecation Strategy**

I propose accepting this PR so this warning goes out with the next release to CRAN (which we will attempt whenever #66 is building and gets merged).

After that release gets to CRAN, I'll submit a PR straight-up removing this function from `uptasticsearch`.

We will wait at least one month to do the next release, giving people time to uncover this deprecation warning.

IF any interest is shown in the function (via people creating `issues`), we can discuss keeping it.
