### PR TITLE
Add better handling for empty bucketed aggregation results

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,11 +177,6 @@ In the example above, we used the [date_histogram](https://www.elastic.co/guide/
 |terms - significant_terms                    |YES          |
 |terms - stats                                |YES          |
 |terms - terms                                |YES          |
-|["stats"](http://bit.ly/2sn1t74)             |YES          |
-
-## Next Steps <a name="nextsteps"></a>
-
-This is a fairly new project and, as the version number indicates, should be regarded as a work in progress.
 
 ### Auth Support <a name="authsupport"></a>
 
@@ -191,7 +186,7 @@ This is a fairly new project and, as the version number indicates, should be reg
 
 When developing on this package, you may want to run Elasticsearch locally to speed up the testing cycle. We've provided some gross bash scripts at the root of this repo to help!
 
-To run the code below, you will need [Docker](https://www.docker.com/). Note that I've passed an argument to `run_es_docker.sh` indicating the major version of ES I want to run. If you don't do that, this script will just run the most recent major version of Elasticsearch. Look at the source code of `run_es_docker.sh` for a list of the valid arguments.
+To run the code below, you will need [Docker](https://www.docker.com/). Note that I've passed an argument to `setup_local.sh` indicating the major version of ES I want to run. If you don't do that, this script will just run the most recent major version of Elasticsearch. Look at the source code of `setup_local.sh` for a list of the valid arguments.
 
 ```
 # Start up Elasticsearch on localhost:9200 and seed it with data

--- a/inst/testdata/empty_terms.json
+++ b/inst/testdata/empty_terms.json
@@ -1,0 +1,22 @@
+{
+  "took": 15,
+  "timed_out": false,
+  "_shards": {
+    "total": 5,
+    "successful": 5,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": 48,
+    "max_score": 0.0,
+    "hits": []
+  },
+  "aggregations": {
+    "blegh": {
+      "doc_count_error_upper_bound": 0,
+      "sum_other_doc_count": 0,
+      "buckets": []
+    }
+  }
+}

--- a/setup_local.sh
+++ b/setup_local.sh
@@ -102,7 +102,7 @@ cp ${SAMPLE_DATA_FILE} ${TESTDIR}/sample.json
 cd ${TESTDIR}
 
 # give the cluster a chance
-sleep 10
+sleep 15
 
 # Create shakespeare index and shakespeare mapping
 curl -X PUT "http://${ES_HOST}:9200/shakespeare" \

--- a/tests/testthat/test-chomp_aggs.R
+++ b/tests/testthat/test-chomp_aggs.R
@@ -594,6 +594,13 @@ test_that("chomp_aggs should work for a two-level 'terms' aggregation",
               expect_true(all(chompDT$customerType == 'type_a'))
           })
 
+# empty results
+test_that("chomp_aggs should work for an empty terms result", {
+    result <- system.file("testdata", "empty_terms.json", package = "uptasticsearch")
+    chompDT <- chomp_aggs(aggs_json = result)
+    expect_null(chompDT)
+})
+
 ##### TEST TEAR DOWN #####
 futile.logger::flog.threshold(origLogThreshold)
 rm(list = ls())

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -166,6 +166,20 @@ futile.logger::flog.threshold(0)
         expect_true(all(outDT[, doc_count > 0]))
     })
     
+    # We have tests on static empty results, but this test will catch
+    # changes across versions in the way ES actually responds to aggs results that
+    # return nothing
+    test_that("es_search correctly handles empty bucketed aggregation result", {
+        outDT <- es_search(
+            es_host = "http://127.0.0.1:9200"
+            , es_index = "shakespeare"
+            , max_hits = 100
+            , query = '{"aggs": {"blegh": {"terms": {"field": "nonsense_field"}}}}'
+        ) 
+        expect_null(outDT)
+    })
+    
+    
 #--- .get_es_version
     
     test_that(".get_version works", {
@@ -205,6 +219,8 @@ futile.logger::flog.threshold(0)
         expect_true(is.character(fieldDT$data_type))
         expect_true(sum(is.na(fieldDT)) == 0)
     })
+    
+
 
 ##### TEST TEAR DOWN #####
 futile.logger::flog.threshold(origLogThreshold)


### PR DESCRIPTION
Currently, running an `aggs` query that is valid but returns no results is handled in a kind-of weird way. This PR just addresses it directly, catching the empty case and logging out the fact that it was empty with an `INFO` level statement.

I don't think this fixes the issue that was reported in #58 (since that turned out to actually be about `reverse_nested` aggs), but gets us a bit closer.