### PR TITLE
hardened handling of aliases

### DIFF
--- a/tests/testthat/test-get_fields.R
+++ b/tests/testthat/test-get_fields.R
@@ -93,20 +93,20 @@ futile.logger::flog.threshold(0)
 #--- .process_alias
     
     # works if one alias is passed
-    test_that(".process_alias works if one alias is included",
+    test_that(".process_new_alias works if one alias is included",
               {
                   alias_string <- 'dwm shakespeare - - -\n'
-                  aliasDT <- uptasticsearch:::.process_alias(alias_string = alias_string)
+                  aliasDT <- uptasticsearch:::.process_new_alias(alias_string = alias_string)
                   expected <- data.table::data.table(alias = 'dwm', index = 'shakespeare')
                   expect_identical(aliasDT, expected)
               }
     )
     
     # works if multiple aliases are passed
-    test_that(".process_alias works if one alias is included",
+    test_that(".process_new_alias works if one alias is included",
               {
                   alias_string <- 'dwm   shakespeare - - -\nmoney bank        - - -\n'
-                  aliasDT <- uptasticsearch:::.process_alias(alias_string = alias_string)
+                  aliasDT <- uptasticsearch:::.process_new_alias(alias_string = alias_string)
                   expected <- data.table::data.table(alias = c('dwm', 'money'), index = c('shakespeare', 'bank'))
                   expect_identical(aliasDT, expected)
               }


### PR DESCRIPTION
Sorry @austin3dickey , one more that I want to go out on the v0.3.0 release.

We don't have any tests right now on how aliases are handled in `get_fields`. This PR addresses that.

One thing to call out is that having multiple aliases point to the same index is a totally valid thing, and our code previously couldn't handle that. This PR adds that support as well.

One other minor bugfix...`url` is a base function, so I changed our internal references to `es_url`. I noticed it because I was getting the dreaded `closure not subsettable` error while debugging.