### PR TITLE
changed strategy for dropping duplicates (fixes #137)

### DIFF
--- a/.ci/before_install.sh
+++ b/.ci/before_install.sh
@@ -4,7 +4,7 @@ set -e
 
 # If language: r,
 # install these testing packages we need
-if [ -z "$TRAVIS_R_VERSION" ];
+if [[ "$TASK" == "rpkg" ]];
 then
   Rscript -e "install.packages(c('devtools', 'knitr', 'testthat', 'rmarkdown'), repos = 'http://cran.rstudio.com')"
 fi

--- a/.ci/before_install.sh
+++ b/.ci/before_install.sh
@@ -1,0 +1,10 @@
+
+# failure is a natural part of life
+set -e
+
+# If language: r,
+# install these testing packages we need
+if [ -z "$TRAVIS_R_VERSION" ];
+then
+  Rscript -e "install.packages(c('devtools', 'knitr', 'testthat', 'rmarkdown'), repos = 'http://cran.rstudio.com')"
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,9 @@ matrix:
     - language: r
       warnings_are_errors: true
       cache: packages
-      env: ES_VERSION=1.0.0
+      env:
+        - ES_VERSION=1.0.0
+        - TASK=rpkg
       install:
         - Rscript -e "devtools::install('r-pkg')"
       script:
@@ -44,7 +46,9 @@ matrix:
     - language: r
       warnings_are_errors: true
       cache: packages
-      env: ES_VERSION=1.4.4
+      env:
+        - ES_VERSION=1.4.4
+        - TASK=rpkg
       install:
         - Rscript -e "devtools::install('r-pkg')"
       script:
@@ -55,7 +59,9 @@ matrix:
     - language: r
       warnings_are_errors: true
       cache: packages
-      env: ES_VERSION=1.7.2
+      env:
+        - ES_VERSION=1.7.2
+        - TASK=rpkg
       install:
         - Rscript -e "devtools::install('r-pkg')"
       script:
@@ -66,7 +72,9 @@ matrix:
     - language: r
       warnings_are_errors: true
       cache: packages
-      env: ES_VERSION=2.0.2
+      env:
+        - ES_VERSION=2.0.2
+        - TASK=rpkg
       install:
         - Rscript -e "devtools::install('r-pkg')"
       script:
@@ -77,7 +85,9 @@ matrix:
     - language: r
       warnings_are_errors: true
       cache: packages
-      env: ES_VERSION=2.1.2
+      env:
+        - ES_VERSION=2.1.2
+        - TASK=rpkg
       install:
         - Rscript -e "devtools::install('r-pkg')"
       script:
@@ -88,7 +98,9 @@ matrix:
     - language: r
       warnings_are_errors: true
       cache: packages
-      env: ES_VERSION=2.2.2
+      env:
+        - ES_VERSION=2.2.2
+        - TASK=rpkg
       install:
         - Rscript -e "devtools::install('r-pkg')"
       script:
@@ -99,7 +111,9 @@ matrix:
     - language: r
       warnings_are_errors: true
       cache: packages
-      env: ES_VERSION=2.3.5
+      env:
+        - ES_VERSION=2.3.5
+        - TASK=rpkg
       install:
         - Rscript -e "devtools::install('r-pkg')"
       script:
@@ -110,7 +124,9 @@ matrix:
     - language: r
       warnings_are_errors: true
       cache: packages
-      env: ES_VERSION=5.0.2
+      env:
+        - ES_VERSION=5.0.2
+        - TASK=rpkg
       install:
         - Rscript -e "devtools::install('r-pkg')"
       script:
@@ -121,7 +137,9 @@ matrix:
     - language: r
       warnings_are_errors: true
       cache: packages
-      env: ES_VERSION=5.3.3
+      env:
+        - ES_VERSION=5.3.3
+        - TASK=rpkg
       install:
         - Rscript -e "devtools::install('r-pkg')"
       script:
@@ -132,7 +150,9 @@ matrix:
     - language: r
       warnings_are_errors: true
       cache: packages
-      env: ES_VERSION=5.4.3
+      env:
+        - ES_VERSION=5.4.3
+        - TASK=rpkg
       install:
         - Rscript -e "devtools::install('r-pkg')"
       script:
@@ -143,7 +163,9 @@ matrix:
     - language: r
       warnings_are_errors: true
       cache: packages
-      env: ES_VERSION=5.6.9
+      env:
+        - ES_VERSION=5.6.9
+        - TASK=rpkg
       install:
         - Rscript -e "devtools::install('r-pkg')"
       script:
@@ -154,7 +176,9 @@ matrix:
     - language: r
       warnings_are_errors: true
       cache: packages
-      env: ES_VERSION=6.0.1
+      env:
+        - ES_VERSION=6.0.1
+        - TASK=rpkg
       install:
         - Rscript -e "devtools::install('r-pkg')"
       script:
@@ -165,7 +189,9 @@ matrix:
     - language: r
       warnings_are_errors: true
       cache: packages
-      env: ES_VERSION=6.1.4
+      env:
+        - ES_VERSION=6.1.4
+        - TASK=rpkg
       install:
         - Rscript -e "devtools::install('r-pkg')"
       script:
@@ -176,7 +202,9 @@ matrix:
     - language: r
       warnings_are_errors: true
       cache: packages
-      env: ES_VERSION=6.2.4
+      env:
+        - ES_VERSION=6.2.4
+        - TASK=rpkg
       install:
         - Rscript -e "devtools::install('r-pkg')"
       script:
@@ -193,98 +221,126 @@ matrix:
         pip install py-pkg/
       script:
         - pytest --verbose py-pkg/
-      env: ES_VERSION=1.0.0
+      env:
+        - ES_VERSION=1.0.0
+        - TASK=pypkg
     - language: python
       python: 3.5
       install:
         pip install py-pkg/
       script:
         - pytest --verbose py-pkg/
-      env: ES_VERSION=1.4.4
+      env:
+        - ES_VERSION=1.4.4
+        - TASK=pypkg
     - language: python
       python: 3.5
       install:
         pip install py-pkg/
       script:
         - pytest --verbose py-pkg/
-      env: ES_VERSION=1.7.2
+      env:
+        - ES_VERSION=1.7.2
+        - TASK=pypkg
     - language: python
       python: 3.5
       install:
         pip install py-pkg/
       script:
         - pytest --verbose py-pkg/
-      env: ES_VERSION=2.0.2
+      env:
+        - ES_VERSION=2.0.2
+        - TASK=pypkg
     - language: python
       python: 3.5
       install:
         pip install py-pkg/
       script:
         - pytest --verbose py-pkg/
-      env: ES_VERSION=2.1.2
+      env:
+        - ES_VERSION=2.1.2
+        - TASK=pypkg
     - language: python
       python: 3.5
       install:
         pip install py-pkg/
       script:
         - pytest --verbose py-pkg/
-      env: ES_VERSION=2.2.2
+      env:
+        - ES_VERSION=2.2.2
+        - TASK=pypkg
     - language: python
       python: 3.5
       install:
         pip install py-pkg/
       script:
         - pytest --verbose py-pkg/
-      env: ES_VERSION=2.3.5
+      env:
+        - ES_VERSION=2.3.5
+        - TASK=pypkg
     - language: python
       python: 3.5
       install:
         pip install py-pkg/
       script:
         - pytest --verbose py-pkg/
-      env: ES_VERSION=5.0.2
+      env:
+        - ES_VERSION=5.0.2
+        - TASK=pypkg
     - language: python
       python: 3.5
       install:
         pip install py-pkg/
       script:
         - pytest --verbose py-pkg/
-      env: ES_VERSION=5.3.3
+      env:
+        - ES_VERSION=5.3.3
+        - TASK=pypkg
     - language: python
       python: 3.5
       install:
         pip install py-pkg/
       script:
         - pytest --verbose py-pkg/
-      env: ES_VERSION=5.4.3
+      env:
+        - ES_VERSION=5.4.3
+        - TASK=pypkg
     - language: python
       python: 3.5
       install:
         pip install py-pkg/
       script:
         - pytest --verbose py-pkg/
-      env: ES_VERSION=5.6.9
+      env:
+        - ES_VERSION=5.6.9
+        - TASK=pypkg
     - language: python
       python: 3.5
       install:
         pip install py-pkg/
       script:
         - pytest --verbose py-pkg/
-      env: ES_VERSION=6.0.1
+      env:
+        - ES_VERSION=6.0.1
+        - TASK=pypkg
     - language: python
       python: 3.5
       install:
         pip install py-pkg/
       script:
         - pytest --verbose py-pkg/
-      env: ES_VERSION=6.1.4
+      env:
+        - ES_VERSION=6.1.4
+        - TASK=pypkg
     - language: python
       python: 3.5
       install:
         pip install py-pkg/
       script:
         - pytest --verbose py-pkg/
-      env: ES_VERSION=6.2.4
+      env:
+        - ES_VERSION=6.2.4
+        - TASK=pypkg
 
 before_script:
   - case "$ES_VERSION" in

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,7 @@ addons:
       - oracle-java8-set-default
 
 before_install:
-  - if [ -z "$TRAVIS_R_VERSION" ]; \
-    then \
-      Rscript -e "install.packages(c('devtools', 'knitr', 'testthat', 'rmarkdown'), repos = 'http://cran.rstudio.com')" \
-    fi
+  - .ci/before_install.sh
 
 # Manually specifying each build configuration.
 # Would be better to figure out how to build a matrix with two

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,12 @@ addons:
     packages:
       - oracle-java8-set-default
 
+before_install:
+  - if [ -z "$TRAVIS_R_VERSION" ]; \
+    then \
+      Rscript -e "install.packages(c('devtools', 'knitr', 'testthat', 'rmarkdown'), repos = 'http://cran.rstudio.com')" \
+    fi
+
 # Manually specifying each build configuration.
 # Would be better to figure out how to build a matrix with two
 # languages but share the ES_VERSION matrix across all builds.
@@ -32,7 +38,6 @@ matrix:
       cache: packages
       env: ES_VERSION=1.0.0
       install:
-        - Rscript -e "install.packages('devtools', repos = 'http://cran.rstudio.com')"
         - Rscript -e "devtools::install('r-pkg')"
       script:
         - R CMD build r-pkg/
@@ -44,7 +49,6 @@ matrix:
       cache: packages
       env: ES_VERSION=1.4.4
       install:
-        - Rscript -e "install.packages('devtools', repos = 'http://cran.rstudio.com')"
         - Rscript -e "devtools::install('r-pkg')"
       script:
         - R CMD build r-pkg/
@@ -56,7 +60,6 @@ matrix:
       cache: packages
       env: ES_VERSION=1.7.2
       install:
-        - Rscript -e "install.packages('devtools', repos = 'http://cran.rstudio.com')"
         - Rscript -e "devtools::install('r-pkg')"
       script:
         - R CMD build r-pkg/
@@ -68,7 +71,6 @@ matrix:
       cache: packages
       env: ES_VERSION=2.0.2
       install:
-        - Rscript -e "install.packages('devtools', repos = 'http://cran.rstudio.com')"
         - Rscript -e "devtools::install('r-pkg')"
       script:
         - R CMD build r-pkg/
@@ -80,7 +82,6 @@ matrix:
       cache: packages
       env: ES_VERSION=2.1.2
       install:
-        - Rscript -e "install.packages('devtools', repos = 'http://cran.rstudio.com')"
         - Rscript -e "devtools::install('r-pkg')"
       script:
         - R CMD build r-pkg/
@@ -92,7 +93,6 @@ matrix:
       cache: packages
       env: ES_VERSION=2.2.2
       install:
-        - Rscript -e "install.packages('devtools', repos = 'http://cran.rstudio.com')"
         - Rscript -e "devtools::install('r-pkg')"
       script:
         - R CMD build r-pkg/
@@ -104,7 +104,6 @@ matrix:
       cache: packages
       env: ES_VERSION=2.3.5
       install:
-        - Rscript -e "install.packages('devtools', repos = 'http://cran.rstudio.com')"
         - Rscript -e "devtools::install('r-pkg')"
       script:
         - R CMD build r-pkg/
@@ -116,7 +115,6 @@ matrix:
       cache: packages
       env: ES_VERSION=5.0.2
       install:
-        - Rscript -e "install.packages('devtools', repos = 'http://cran.rstudio.com')"
         - Rscript -e "devtools::install('r-pkg')"
       script:
         - R CMD build r-pkg/
@@ -128,7 +126,6 @@ matrix:
       cache: packages
       env: ES_VERSION=5.3.3
       install:
-        - Rscript -e "install.packages('devtools', repos = 'http://cran.rstudio.com')"
         - Rscript -e "devtools::install('r-pkg')"
       script:
         - R CMD build r-pkg/
@@ -140,7 +137,6 @@ matrix:
       cache: packages
       env: ES_VERSION=5.4.3
       install:
-        - Rscript -e "install.packages('devtools', repos = 'http://cran.rstudio.com')"
         - Rscript -e "devtools::install('r-pkg')"
       script:
         - R CMD build r-pkg/
@@ -152,7 +148,6 @@ matrix:
       cache: packages
       env: ES_VERSION=5.6.9
       install:
-        - Rscript -e "install.packages('devtools', repos = 'http://cran.rstudio.com')"
         - Rscript -e "devtools::install('r-pkg')"
       script:
         - R CMD build r-pkg/
@@ -164,7 +159,6 @@ matrix:
       cache: packages
       env: ES_VERSION=6.0.1
       install:
-        - Rscript -e "install.packages('devtools', repos = 'http://cran.rstudio.com')"
         - Rscript -e "devtools::install('r-pkg')"
       script:
         - R CMD build r-pkg/
@@ -176,7 +170,6 @@ matrix:
       cache: packages
       env: ES_VERSION=6.1.4
       install:
-        - Rscript -e "install.packages('devtools', repos = 'http://cran.rstudio.com')"
         - Rscript -e "devtools::install('r-pkg')"
       script:
         - R CMD build r-pkg/
@@ -188,7 +181,6 @@ matrix:
       cache: packages
       env: ES_VERSION=6.2.4
       install:
-        - Rscript -e "install.packages('devtools', repos = 'http://cran.rstudio.com')"
         - Rscript -e "devtools::install('r-pkg')"
       script:
         - R CMD build r-pkg/

--- a/r-pkg/R/es_search.R
+++ b/r-pkg/R/es_search.R
@@ -100,7 +100,7 @@ es_search <- function(es_host
         )
         log_fatal(msg)
     }
-  
+
     # assign 1 core by default, if the number of cores is NA
     if (is.na(n_cores) || !assertthat::is.count(n_cores)){
       msg <- "detectCores() returned NA. Assigning number of cores to be 1."
@@ -397,7 +397,7 @@ es_search <- function(es_host
 
     # It's POSSIBLE that the parallel process gave us duplicates. Correct for that
     data.table::setkeyv(outDT, NULL)
-    outDT <- unique(outDT)
+    outDT <- unique(outDT, by = "_id")
 
     # Check we got the number of unique records we expected
     if (nrow(outDT) < hits_to_pull && break_on_duplicates){


### PR DESCRIPTION
This addresses #137 . To be honest, we should have been unique-ing by `_id` anyway.

I feel ok about this change because you can't actually avoid `_id` being a part of each hit (AFAIK), even if you do the `"source": {"include"` trick.