### PR TITLE
Removed TODOs in code

### DIFF
--- a/py-pkg/uptasticsearch/fetch_all.py
+++ b/py-pkg/uptasticsearch/fetch_all.py
@@ -33,7 +33,6 @@ def es_search(es_host, es_index, query_body="{}", size=10000, max_hits=None,
               "and will only return aggregation results."
         print(msg)
 
-        # TODO (james.lamb@uptake.com): implemented the aggs parser
         raise NotImplementedError("es_search aggs parser has not been implemented yet!")
 
     else:


### PR DESCRIPTION
My new thing for 2019 is being an "issues are better than TODOs" ideologue.

I ran `git grep -i 'todo'` on this project tonight and found only one! That one TODO is already covered by many open issues, for example #98 , so no new issues need to be opened.