### PR TITLE
[ci] remove codecov, enforce zizmor checks

### DIFF
--- a/.ci/report_to_covr.sh
+++ b/.ci/report_to_covr.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# failure is a natural part of life
-set -e -u -o pipefail
-
-Rscript -e " \
-    Sys.setenv(NOT_CRAN = 'true'); \
-    covr::codecov('r-pkg/') \
-    "

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -19,5 +19,5 @@ sudo apt-get install \
     tidy \
     qpdf
 
-Rscript -e "install.packages(c('covr', 'curl', 'data.table', 'jsonlite', 'knitr', 'lintr', 'markdown', 'purrr', 'stringr', 'testthat'), repos = 'https://cran.r-project.org', Ncpus = parallel::detectCores())"
+Rscript -e "install.packages(c('curl', 'data.table', 'jsonlite', 'knitr', 'lintr', 'markdown', 'purrr', 'stringr', 'testthat'), repos = 'https://cran.r-project.org', Ncpus = parallel::detectCores())"
 cp test-data/* r-pkg/inst/testdata/

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 10
     groups:
       ci-dependencies:
         patterns:

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -4,6 +4,10 @@ concurrency:
   group: docs-build-on-${{ github.event_name }}-from-${{ github.ref_name }}
   cancel-in-progress: true
 
+# default to 0 permissions
+# (job-level overrides add the minimal permissions needed)
+permissions:
+  contents: none
 
 on:
   # run only when called by other workflows

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -4,6 +4,11 @@ concurrency:
   group: docs-build-on-${{ github.event_name }}-from-${{ github.ref_name }}
   cancel-in-progress: true
 
+# default to 0 permissions
+# (job-level overrides add the minimal permissions needed)
+permissions:
+  contents: none
+
 on:
   # run only when called by other workflows
   workflow_call:
@@ -17,21 +22,23 @@ on:
 jobs:
   build:
     runs-on: macos-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: set up R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 #v2.11.4
         with:
           r-version: release
       - name: set up pandoc
-        uses: r-lib/actions/setup-pandoc@v2
+        uses: r-lib/actions/setup-pandoc@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 #v2.11.4
       - name: build docs
         run: |
           .ci/build-docs.sh
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: ./r-pkg/docs
 
@@ -54,4 +61,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -4,10 +4,6 @@ concurrency:
   group: docs-build-on-${{ github.event_name }}-from-${{ github.ref_name }}
   cancel-in-progress: true
 
-# default to 0 permissions
-# (job-level overrides add the minimal permissions needed)
-permissions:
-  contents: none
 
 on:
   # run only when called by other workflows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,6 @@ env:
 jobs:
   build-docs:
     uses: ./.github/workflows/build-docs.yaml
-    permissions:
-      contents: read
     with:
       deploy: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags')) || (github.event_name == 'workflow_dispatch' && inputs.deploy-docs == true) }}
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# default to 0 permissions
+# (job-level overrides add the minimal permissions needed)
+permissions:
+  contents: none
+
 env:
   # parallelize compilation (extra important for Linux, where CRAN doesn't supply pre-compiled binaries)
   MAKEFLAGS: "-j4"
@@ -27,22 +32,25 @@ env:
 jobs:
   build-docs:
     uses: ./.github/workflows/build-docs.yaml
+    permissions:
+      contents: read
     with:
       deploy: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags')) || (github.event_name == 'workflow_dispatch' && inputs.deploy-docs == true) }}
-    secrets: inherit
   lint:
     name: lint
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
       - name: set up R
-        uses: r-lib/actions/setup-r@v2
+        uses: &setup_r r-lib/actions/setup-r@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
       - name: run lintr
         run: |
           Rscript -e "install.packages('lintr')"
@@ -68,15 +76,16 @@ jobs:
           - 8.17.2
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
+          persist-credentials: false
       - name: set up R
-        uses: r-lib/actions/setup-r@v2
+        uses: *setup_r
         with:
           r-version: release
       - name: set up pandoc
-        uses: r-lib/actions/setup-pandoc@v2
+        uses: r-lib/actions/setup-pandoc@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
       - name: run tests
         shell: bash
         run: |
@@ -85,7 +94,6 @@ jobs:
           $GITHUB_WORKSPACE/.ci/install.sh
           $GITHUB_WORKSPACE/setup_local.sh ${{ matrix.es_version }}
           $GITHUB_WORKSPACE/.ci/test.sh
-          $GITHUB_WORKSPACE/.ci/report_to_covr.sh
   all-successful:
     if: always()
     runs-on: ubuntu-latest
@@ -93,8 +101,10 @@ jobs:
       - build-docs
       - lint
       - test
+    permissions:
+      statuses: read
     steps:
       - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@v1.2.2
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ env:
 jobs:
   build-docs:
     uses: ./.github/workflows/build-docs.yaml
+    permissions:
+      contents: read
+      id-token: write
+      pages: write
     with:
       deploy: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags')) || (github.event_name == 'workflow_dispatch' && inputs.deploy-docs == true) }}
   lint:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,10 @@ repos:
       - id: shellcheck
         args: ["--exclude=SC2002"]
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
       - id: codespell
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: 'v1.23.1'
+    hooks:
+      - id: zizmor

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # uptasticsearch
 
 [![GitHub Actions Build Status](https://github.com/uptake/uptasticsearch/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/uptake/uptasticsearch/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/uptake/uptasticsearch/branch/main/graph/badge.svg)](https://app.codecov.io/gh/uptake/uptasticsearch)
 [![CRAN\_Status\_Badge](https://www.r-pkg.org/badges/version-last-release/uptasticsearch)](https://cran.r-project.org/package=uptasticsearch)
 [![CRAN\_Download\_Badge](https://cranlogs.r-pkg.org/badges/grand-total/uptasticsearch)](https://cran.r-project.org/package=uptasticsearch)
 


### PR DESCRIPTION
Proposes a batch of security fixes:

* removes codecov (I'll click the buttons to revoke the app's access once this is merged)
* enforces `zizmor` checks

## Notes for Reviewers

I also made some manual changes at https://github.com/uptake/uptasticsearch/settings/actions

* only allow third-party actions matching an allowlist in the repo's settings
* default all workflow permissions to read-only
* require approval for CI to run for first-time contributors