### PR TITLE
[ci]: fix installation of {fs}, update pre-commit hooks

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -12,6 +12,7 @@ sudo apt-get install \
     libcurl4-openssl-dev \
     curl \
     devscripts \
+    libuv1-dev \
     texinfo \
     texlive-latex-recommended \
     texlive-fonts-recommended \

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,6 @@ repos:
     hooks:
       - id: codespell
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: 'v1.23.1'
+    rev: 'v1.24.1'
     hooks:
       - id: zizmor


### PR DESCRIPTION
Linux CI is failing like this:

```text
** package ‘fs’ successfully unpacked and MD5 sums checked
** using staged installation
Package libuv was not found in the pkg-config search path.
Perhaps you should add the directory containing `libuv.pc'
to the PKG_CONFIG_PATH environment variable
Package 'libuv', required by 'virtual:world', not found
Using PKG_CFLAGS=
Using PKG_LIBS=-luv
--------------------------- [CONFIGURE] --------------------------------
Configuration failed because libuv was not found. Try installing:
 * deb: libuv1-dev (Debian, Ubuntu, etc)
 * rpm: libuv-devel (Fedora, EPEL)
 * brew: libuv (OSX)
Alternatively set environment variable USE_BUNDLED_LIBUV=1 to build a static
version of libuv that is included with this package.
```

([build link](https://github.com/uptake/uptasticsearch/actions/runs/25241204178/job/74017293340?pr=267#step:5:1578))

Recent changes in `{fs}` mean everyone that ends up building it from source now needs to either system install `libuv` or install CMake and set an environment variable... see https://github.com/lightgbm-org/LightGBM/issues/7208 for more details.

This PR proposes using the system install of `libuv` (should be faster and less error-prone than building it from source in the `{fs}` build).

Also updates hooks w/ `pre-commit autoupdate`, just routine minor maintenance I wanted to tack on here to take advantage of the review and CI runs.